### PR TITLE
Add support for repositories from GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lot of times we have to look at files on GitHub.  But this intrudes our ideal 
 
 *Git It On*, the plugin for zshell, comes in here.
 
-* `gitit` -- open your current folder, on your current branch, in GitHub
+* `gitit` -- open your current folder, on your current branch, in GitHub or GitLab
 * `gitit <folder or file>` -- opens that folder in your current branch (paths are relative)
 
 
@@ -46,6 +46,8 @@ curl -s https://raw.githubusercontent.com/peterhurford/git-it-on.zsh/master/git-
 
 ## That's cool... What else?
 
+### Well, for GitHub:
+
 * `gitit <folder or file> <branch>` -- opens that folder on the specified branch.
 * `gitit repo <username> <reponame>` -- opens up the specified repository.
 * `gitit branch <branch>` -- open the repo for a chosen branch.
@@ -65,7 +67,23 @@ curl -s https://raw.githubusercontent.com/peterhurford/git-it-on.zsh/master/git-
 * `gitit branches mine` -- open up a list of your branches.
 * `gitit grep <term>` -- opens the github search page for your term
 * `gitit ctrlp` -- opens the github file finder for master branch (note that you cannot pass search terms directly from the command line)
-* `giti ctrlp <branch>` -- opens the github file finder for your desired branch
+* `gitit ctrlp <branch>` -- opens the github file finder for your desired branch
+
+### And for GitLab:
+
+* `gitit <folder or file> <branch>` -- opens that folder on the specified branch.
+* `gitit glcompare` -- open a comparison for current branch to `master`
+* `gitit glcompare <src>` -- open a comparison for `src` to `master`
+* `gitit glcompare <src> <target>` -- open a comparison for `src` to `target`
+* `gitit glcommits <file>` -- open all commits; optionally specify `file` for all commits affecting it
+* `gitit glbranches` -- open the list of branches
+* `gitit glhistory <file> <branch>` -- open history of the current branch; optionally specify `file` and `branch`
+* `gitit glmerges` -- open merge requests page
+* `gitit glmerges <query>` -- open the list of pull requests with query (e.g. `variable_1`)
+* `gitit glmerges <number>` -- open page for merge request `<number>`
+* `gitit glissues <query|number>` -- similar to `glmerges`
+* `gitit glctrlp <query>` -- search using the gitlab file finder
+* `gitit glnetwork` -- open the GitLab repository graph
 
 
 ## But why even leave vim for the command line?

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ curl -s https://raw.githubusercontent.com/peterhurford/git-it-on.zsh/master/git-
 * `gitit glctrlp <query>` -- search using the gitlab file finder
 * `gitit glnetwork` -- open the GitLab repository graph
 
+#### Gitlab Short Commands:
+Gitlab commands also have short alternatives:  
+`glcompare|glcm, glcommits|glco, glhistory|glh, glbranches|glb, glmerges|glm, glissues|gli, glctrlp|glcr, glnetwork|gln`
+
 
 ## But why even leave vim for the command line?
 TODO: Make and link vim companion plugin.

--- a/git-it-on.plugin.zsh
+++ b/git-it-on.plugin.zsh
@@ -231,7 +231,7 @@ git_help() {
   echo 'Available first arguments for GitHub repos:'
   echo -e '\tcompare, commits, history, branch, branches, pulls, issues, grep, ctrlp, repo, help'
   echo 'For GitLab repos:'
-  echo -e '\tglcompare, glcommits, glhistory, glbranches, glmerges, glissues, glctrlp, glnetwork, help'
+  echo -e '\tglcompare|glcm, glcommits|glco, glhistory|glh, glbranches|glb, glmerges|glm, glissues|gli, glctrlp|glcr, glnetwork|gln, help'
 }
 
 
@@ -252,14 +252,14 @@ gitit() {
   elif [ $gitit_command = "repo" ]; then git_open_repo $2 $3
 
   # gitlab commands
-  elif [ $gitit_command = "glcompare" ]; then git_open_commits $2
-  elif [ $gitit_command = "glcommits" ]; then git_open_commits $2
-  elif [ $gitit_command = "glhistory" ]; then git_open_history $2 $3
-  elif [ $gitit_command = "glbranches" ]; then gitlab_open_branches
-  elif [ $gitit_command = "glmerges" ]; then gitlab_open_merges $@
-  elif [ $gitit_command = "glissues" ]; then git_open_issues $@
-  elif [ $gitit_command = "glctrlp" ]; then gitlab_ctrlp $2
-  elif [ $gitit_command = "glnetwork" ]; then gitlab_open_network
+  elif [ $gitit_command = "glcompare" ]  || [ $gitit_command = "glcm" ]; then gitlab_open_compare $@
+  elif [ $gitit_command = "glcommits" ]  || [ $gitit_command = "glco" ]; then git_open_commits $2
+  elif [ $gitit_command = "glhistory" ]  || [ $gitit_command = "glh" ]; then git_open_history $2 $3
+  elif [ $gitit_command = "glbranches" ] || [ $gitit_command = "glb" ]; then gitlab_open_branches
+  elif [ $gitit_command = "glmerges" ]   || [ $gitit_command = "glm" ]; then gitlab_open_merges $@
+  elif [ $gitit_command = "glissues" ]   || [ $gitit_command = "gli" ]; then git_open_issues $@
+  elif [ $gitit_command = "glctrlp" ]    || [ $gitit_command = "glcr" ]; then gitlab_ctrlp $2
+  elif [ $gitit_command = "glnetwork" ]  || [ $gitit_command = "gln" ]; then gitlab_open_network
 
   elif [ $gitit_command = "help" ]; then git_help
   else git_open_file $1 $2

--- a/git-it-on.plugin.zsh
+++ b/git-it-on.plugin.zsh
@@ -19,9 +19,21 @@ __set_local_branch() {
     branch=$(git rev-parse --abbrev-ref HEAD)
 }
 
+# check if local branch is tracked upstream;
+# if not, set $branch to first remote branch (probably master from origin/master)
+__fix_local_untracked_branch() {
+  for line in $(git rev-parse --abbrev-ref --remotes); do
+    if [[ "$branch" == ${line/*\//} ]]; then return true; fi
+  done
+
+  local _branch=$(git rev-parse --abbrev-ref --remotes | head -n1)
+  branch=${_branch/*\//}
+}
+
 git_set_repo() {
   repo_url=$(git config --get remote.origin.url)
   if ! __set_remote_branch; then __set_local_branch; fi
+  __fix_local_untracked_branch
   url="${repo_url/git/https}"
   url="${url/httpshub/github}"
   url="${url/.git/}"

--- a/git-it-on.plugin.zsh
+++ b/git-it-on.plugin.zsh
@@ -27,6 +27,8 @@ git_set_repo() {
   url="${url/.git/}"
   url="${url/https@/https://}"
   url="${url/com:/com/}"
+  url="${url/edu:/edu/}"
+  url="${url/org:/org/}"
   url="${url/ssh:\/\/}"
 }
 
@@ -170,6 +172,54 @@ git_open_repo() {
   fi
 }
 
+gitlab_open_compare() {
+	git_set_repo
+	shift
+	if [ "$#" -eq 0 ]; then
+		src="$(git rev-parse --abbrev-ref HEAD)"
+		target="master"
+	elif [ "$#" -eq 1 ]; then
+		src="$(git rev-parse --abbrev-ref HEAD)"
+		target="$1"
+	else
+		src="$2"
+		target="$1"
+	fi
+	__open "$url/compare/$target...$src"
+}
+
+gitlab_open_branches() {
+  git_set_repo
+  __open "$url/branches"
+}
+
+gitlab_open_network() {
+	git_set_repo
+	local branch="$(git rev-parse --abbrev-ref HEAD)"
+	__open "$url/network/$branch"
+}
+
+gitlab_ctrlp() {
+  git_set_repo
+  if [ "$#" -eq 0 ]; then
+    branch="master"
+  else
+    branch=$1
+  fi
+  __open "$url/find_file/$branch"
+}
+
+gitlab_open_merges() {
+  git_set_repo
+  shift
+  if [ "$#" -eq 0 ]; then
+    __open "$url/merge_requests"
+  elif [ $1 -ge 0 2>/dev/null ]; then
+    __open "$url/merge_requests/$1"
+  else
+    __open "$url/merge_requests?scope=all&utf8=✓&state=opened&search=$@"
+  fi
+}
 
 git_help() {
   echo 'GIT IT ON'
@@ -185,6 +235,8 @@ git_help() {
 gitit() {
   gitit_command="$1"
   if [ $# -eq 0 ]; then git_open_file
+
+  # github commands
   elif [ $gitit_command = "compare" ]; then git_open_compare $2
   elif [ $gitit_command = "commits" ]; then git_open_commits $2
   elif [ $gitit_command = "history" ]; then git_open_history $2 $3
@@ -195,6 +247,17 @@ gitit() {
   elif [ $gitit_command = "grep" ]; then git_grep $@
   elif [ $gitit_command = "ctrlp" ]; then git_ctrlp $2
   elif [ $gitit_command = "repo" ]; then git_open_repo $2 $3
+
+  # gitlab commands
+  elif [ $gitit_command = "glcompare" ]; then git_open_commits $2
+  elif [ $gitit_command = "glcommits" ]; then git_open_commits $2
+  elif [ $gitit_command = "glhistory" ]; then git_open_history $2 $3
+  elif [ $gitit_command = "glbranches" ]; then gitlab_open_branches
+  elif [ $gitit_command = "glmerges" ]; then gitlab_open_merges $@
+  elif [ $gitit_command = "glissues" ]; then git_open_issues $@
+  elif [ $gitit_command = "glctrlp" ]; then gitlab_ctrlp $2
+  elif [ $gitit_command = "glnetwork" ]; then gitlab_open_network
+
   elif [ $gitit_command = "help" ]; then git_help
   else git_open_file $1 $2
   fi

--- a/git-it-on.plugin.zsh
+++ b/git-it-on.plugin.zsh
@@ -224,11 +224,14 @@ gitlab_open_merges() {
 git_help() {
   echo 'GIT IT ON'
   echo '============='
-  echo '* `gitit` -- open your current folder, on your current branch, in GitHub.'
+  echo '* `gitit` -- open your current folder, on your current branch, in GitHub or GitLab.'
   echo '* `gitit <folder or file>` -- open that folder in your current branch (paths are relative).'
   echo '* For more, visit https://github.com/peterhurford/git-it-on.zsh or type `gitit repo peterhurford git-it-on.zsh`'
   echo ''
-  echo 'Available first arguments: compare, commits, history, branch, branches, pulls, issues, grep, ctrlp, repo, help'
+  echo 'Available first arguments for GitHub repos:'
+  echo -e '\tcompare, commits, history, branch, branches, pulls, issues, grep, ctrlp, repo, help'
+  echo 'For GitLab repos:'
+  echo -e '\tglcompare, glcommits, glhistory, glbranches, glmerges, glissues, glctrlp, glnetwork, help'
 }
 
 


### PR DESCRIPTION
Made some modifications so `gitit` will work with GitLab instances also.
* Since companies/research organizations host GitLab servers the address may end in `.org`or `.edu` - there might be a better way to replace a trailing `:` in a git remote but I'm not sure of all the possible ways the url could look.
* Added commands (prefixed with `gl`):

Added:
* `glcompare`
* `glbranches`
* `glmerges`
* `glctrlp`
* `glnetwork`

Commands that already worked (just mapped to the github commands):
* `glcommits`
* `glhistory`
* `glissues`

Not feasible for GitLab:
* `pulls` (pulls not a thing on gl; added `glmerges` instead)
* `grep` (requires project ID, because searches are across all repos you have access to)
* `repo` (not as useful for gl - would require whole url or prior configuration to point at specific gitlab instance)


Note -
Tried to match up with your code style and make only minimal edits to the help docs to keep it consistent. I did add short alternatives for the GitLab commands since they're a bit longer, but feel free to remove those from the PR if you don't want hardcoded short commands.