### PR TITLE
Add "net" domain to git_set_repo() function

### DIFF
--- a/git-it-on.plugin.zsh
+++ b/git-it-on.plugin.zsh
@@ -42,6 +42,7 @@ git_set_repo() {
   url="${url/.git/}"
   url="${url/https@/https://}"
   url="${url/com:/com/}"
+  url="${url/net:/net/}"
   url="${url/edu:/edu/}"
   url="${url/org:/org/}"
   url="${url/ssh:\/\/}"


### PR DESCRIPTION
@peterhurford right now Gitlab repos with **net** domains are not working as **git_set_repo()** function does not replace "**:**" symbol from fetched repo url :) Tried this on my fork locally with Gitlab repo and it worked.